### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ gem 'render_sync'
 
 ```bash
 $ bundle
-$ rails g sync:install
+$ rails g render_sync:install
 ```
 
 #### 2) Require sync in your asset javascript manifest `app/assets/javascripts/application.js`:


### PR DESCRIPTION
Updated readme to reference new `render_sync:install` generator (replacing `sync:install` which is no longer defined).